### PR TITLE
Pin tensorflow to 2.8.x, tensorflow-io to 0.24.x, and tensorflow-model-optimization to 0.7.2

### DIFF
--- a/ml_audio_classifier_example_for_pico.ipynb
+++ b/ml_audio_classifier_example_for_pico.ipynb
@@ -139,7 +139,7 @@
         "id": "B6CQatks4z4p"
       },
       "source": [
-        "!pip install librosa matplotlib pandas tensorflow tensorflow-io==0.24.0 tensorflow-model-optimization\n",
+        "!pip install librosa matplotlib pandas \"tensorflow==2.8.*\" \"tensorflow-io==0.24.*\" \"tensorflow-model-optimization==0.7.2\"\n",
         "\n",
         "!pip install git+https://github.com/ARM-software/CMSIS_5.git@5.8.0#egg=CMSISDSP\\&subdirectory=CMSIS/DSP/PythonWrapper"
       ],


### PR DESCRIPTION
Needed to pin some dependencies for notebook to work on Colab:

* tensorflow to 2.8.x
* tensorflow-io to 0.24.x
* tensorflow-model-optimization to 0.7.2